### PR TITLE
SP3-CC - Edit Account Don't allow user to change initial balance

### DIFF
--- a/app/views/accounts/_form.html.erb
+++ b/app/views/accounts/_form.html.erb
@@ -28,7 +28,11 @@
       <div class="input-group-prepend">
         <span class="input-group-text">$</span>
       </div>
-      <%= f.text_field :initial_balance, required: true, class: 'form-control' %>
+      <% if !@account.name.nil? %>
+        <%= f.text_field :initial_balance, required: true, readonly: true, class: 'form-control' %>
+      <% else %>
+        <%= f.text_field :initial_balance, required: true, class: 'form-control' %>
+      <% end %>
     </div>
   </div>
 


### PR DESCRIPTION
Initial balance cannot be changed in edit for accounts. James and I worked on this and we both think it's okay to use account.name as a reference. We were having issues with using initial_balance.